### PR TITLE
Fix CORS issue

### DIFF
--- a/src/eventPage.js
+++ b/src/eventPage.js
@@ -29,7 +29,7 @@
             return { requestHeaders: details.requestHeaders };
         },
         { urls: ['<all_urls>'] },
-        ['blocking', 'requestHeaders']
+        ['blocking', 'requestHeaders', 'extraHeaders']
     );
     browser.storage.onChanged.addListener((changes, namespace) => {
         console.log("storage changed", changes);


### PR DESCRIPTION
This fixes #14
From chrome documentation (https://developer.chrome.com/extensions/webRequest)

> Starting from Chrome 79, the webRequest API does not intercept CORS preflight requests and responses by default. A CORS preflight for a request URL is visible to an extension if there is a listener with 'extraHeaders' specified in opt_extraInfoSpec for the request URL. onBeforeRequest can also take 'extraHeaders' from Chrome 79.

This change adds `extraHeaders`, thus fixing many websites from breaking.