### PR TITLE
Fix includeDomains property from changing automatically

### DIFF
--- a/src/components/form.ts
+++ b/src/components/form.ts
@@ -183,10 +183,12 @@ export class ProfileFormElement extends LitElement {
         let { id , value , required} = event.target as HTMLInputElement;
         if(id === "headers") {
             this.headers = Array.from((event.target as HTMLSelectElement).selectedOptions, option => option.value);
-        } else if(["name", "value", "includeDomains", "domains"].includes(id)) {
+        } else if(["name", "value", "domains"].includes(id)) {
             this[id] = value.trim();
         } else if(id === "allDomains") {
             this.allDomains = (value === "true");
+        } else if (id === "includeDomains") {
+            this.includeDomains = (value === "true");
         }
 
         if(required) {
@@ -214,7 +216,7 @@ export class ProfileFormElement extends LitElement {
             value: this.value,
             headers: this.headers,
             // @ts-ignore
-            includeDomains: this.includeDomains !== "false",
+            includeDomains: this.includeDomains,
             domains: this.domains,
         }
 


### PR DESCRIPTION
This fixes #44 

Changes:

1. Modified _save method to keep includeDomains value unchanged.
2. Updated _handleInput method to avoid unnecessary checks.
3. Added condition in _handleInput to correctly update includeDomains.
