### PR TITLE
Add confirmation dialog for profile deletion

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -134,5 +134,19 @@
   },
   "status_disabled": {
     "message": "Disabled"
+  },
+  "confirm_delete_message": {
+      "message": "Are you sure to delete [$name$] Profiles?",
+      "placeholders": {
+          "name": {
+              "content": "$1"
+          }
+      }
+  },
+  "btn_yes": {
+      "message": "Yes"
+  },
+  "btn_cancel": {
+      "message": "No"
   }
 }

--- a/src/components/form.ts
+++ b/src/components/form.ts
@@ -183,10 +183,12 @@ export class ProfileFormElement extends LitElement {
         let { id , value , required} = event.target as HTMLInputElement;
         if(id === "headers") {
             this.headers = Array.from((event.target as HTMLSelectElement).selectedOptions, option => option.value);
-        } else if(["name", "value", "includeDomains", "domains"].includes(id)) {
+        } else if(["name", "value", "domains"].includes(id)) {
             this[id] = value.trim();
         } else if(id === "allDomains") {
             this.allDomains = (value === "true");
+        } else if (id === "includeDomains") {
+            this.includeDomains = (value === "true");
         }
 
         if(required) {
@@ -214,7 +216,7 @@ export class ProfileFormElement extends LitElement {
             value: this.value,
             headers: this.headers,
             // @ts-ignore
-            includeDomains: this.includeDomains !== "false",
+            includeDomains: this.includeDomains,
             domains: this.domains,
         }
 


### PR DESCRIPTION
This enhancement improves the user experience by adding a confirmation dialog when deleting profiles in the X-Forwarded-For extension. 

Previously, clicking the "Delete" button would immediately remove a profile without any warning, which could lead to accidental deletions. I've been through it, and it was very painful.

**Changes**:

- Added a two-step confirmation process for profile deletion
- Displays a modal dialog asking before proceeding
- Requires explicit confirmation via "Yes" button to complete the deletion
- Includes "No" option to abort the deletion process
